### PR TITLE
Incorrect confluence RPC service URL creation

### DIFF
--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/Util.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/Util.java
@@ -5,7 +5,7 @@ import java.util.logging.Logger;
 
 /**
  * Utility methods
- * 
+ *
  * @author Joe Hansche <jhansche@myyearbook.com>
  */
 public class Util {
@@ -19,23 +19,25 @@ public class Util {
 
     /**
      * Convert a generic Confluence URL into the XmlRpc endpoint URL
-     * 
+     *
      * @param url
      * @return
      * @see #XML_RPC_URL_PATH
      */
     public static String confluenceUrlToXmlRpcUrl(String url) {
-	return URI.create(url).resolve(XML_RPC_URL_PATH).toString();
+	URI uri = URI.create(url);
+	return uri.resolve(uri.getPath() + XML_RPC_URL_PATH).normalize().toString();
     }
 
     /**
      * Convert a generic Confluence URL into the SOAP endpoint URL
-     * 
+     *
      * @param url
      * @return
      * @see #SOAP_URL_PATH
      */
     public static String confluenceUrlToSoapUrl(String url) {
-	return URI.create(url).resolve(SOAP_URL_PATH).toString();
+	URI uri = URI.create(url);
+	return uri.resolve(uri.getPath() + SOAP_URL_PATH).normalize().toString();
     }
 }

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/rpc/XmlRpcClient.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/rpc/XmlRpcClient.java
@@ -16,9 +16,8 @@ public class XmlRpcClient {
 
     public static ConfluenceSoapService getInstance(String url) throws RemoteException {
 	try {
-	    String rpcUrl = Util.confluenceUrlToSoapUrl(url);
 	    final ConfluenceSoapServiceServiceLocator locator = new ConfluenceSoapServiceServiceLocator();
-	    locator.setConfluenceserviceV1EndpointAddress(rpcUrl);
+	    locator.setConfluenceserviceV1EndpointAddress(url);
 	    return locator.getConfluenceserviceV1();
 	} catch (ServiceException e) {
 	    throw new RemoteException("Failed to create SOAP Client", e);


### PR DESCRIPTION
When confluence is not installed on the "/" path of the server (e.g. http://example.com/confluence/) the path element of the base URL is truncated (e.g. http://example.com/rpc/soap-axis/confluenceservice-v1) and the RPC service URL is incorrect leading to HTTP 404 error.
