### PR TITLE
Implement support for pipelines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,7 @@
     </parent>
 	  
     <properties>
-        <jenkins-test-harness.version>2.18</jenkins-test-harness.version>
-        <jenkins.version>1.609.1</jenkins.version>
+        <jenkins.version>1.651.3</jenkins.version>
         <java.level>7</java.level>
         <no-test-jar>false</no-test-jar>
         <!-- Use the same configuration than before. -->
@@ -70,6 +69,11 @@
     </developers>
 
     <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.2</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.axis</groupId>
             <artifactId>axis</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>1.13</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
             <version>1.2</version>

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/ConfluenceDSL.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/ConfluenceDSL.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Francois Ferrand
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.myyearbook.hudson.plugins.confluence;
+
+import groovy.lang.Binding;
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.cps.CpsScript;
+import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
+
+@Extension
+public class ConfluenceDSL extends GlobalVariable {
+    @Override
+    public String getName() {
+        return "publishConfluence";
+    }
+
+    @Override
+    public Object getValue(CpsScript script) throws Exception {
+        Binding binding = script.getBinding();
+
+        Object confluenceDsl;
+        if (binding.hasVariable(getName())) {
+            confluenceDsl = binding.getVariable(getName());
+        } else {
+            confluenceDsl = script.getClass().getClassLoader()
+                    .loadClass("com.myyearbook.hudson.plugins.confluence." + getName())
+                    .newInstance();
+            binding.setVariable(getName(), confluenceDsl);
+        }
+        return confluenceDsl;
+    }
+}

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/AfterTokenEditor.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/AfterTokenEditor.java
@@ -15,7 +15,7 @@ package com.myyearbook.hudson.plugins.confluence.wiki.editors;
 
 import hudson.Extension;
 import hudson.Util;
-import hudson.model.BuildListener;
+import hudson.model.TaskListener;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -38,7 +38,7 @@ public class AfterTokenEditor extends MarkupEditor {
     }
 
     @Override
-    public String performEdits(final BuildListener listener, final String content,
+    public String performEdits(final TaskListener listener, final String content,
             final String generated, final boolean isNewFormat) throws TokenNotFoundException {
         final StringBuffer sb = new StringBuffer(content);
 

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/AfterTokenEditor.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/AfterTokenEditor.java
@@ -17,6 +17,7 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.myyearbook.hudson.plugins.confluence.wiki.generators.MarkupGenerator;
@@ -63,6 +64,7 @@ public class AfterTokenEditor extends MarkupEditor {
     }
 
     @Extension
+    @Symbol("confluenceAfterToken")
     public static final class DescriptorImpl extends MarkupEditorDescriptor {
         @Override
         public String getDisplayName() {

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/AppendEditor.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/AppendEditor.java
@@ -16,6 +16,7 @@ package com.myyearbook.hudson.plugins.confluence.wiki.editors;
 import hudson.Extension;
 import hudson.model.TaskListener;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.myyearbook.hudson.plugins.confluence.wiki.generators.MarkupGenerator;
@@ -47,6 +48,7 @@ public class AppendEditor extends MarkupEditor {
     }
 
     @Extension
+    @Symbol("confluenceAppendPage")
     public static final class DescriptorImpl extends MarkupEditorDescriptor {
         @Override
         public String getDisplayName() {

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/AppendEditor.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/AppendEditor.java
@@ -14,7 +14,7 @@
 package com.myyearbook.hudson.plugins.confluence.wiki.editors;
 
 import hudson.Extension;
-import hudson.model.BuildListener;
+import hudson.model.TaskListener;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -33,7 +33,7 @@ public class AppendEditor extends MarkupEditor {
     }
 
     @Override
-    public String performEdits(final BuildListener listener, final String content,
+    public String performEdits(final TaskListener listener, final String content,
             final String generated, final boolean isNewFormat) {
         final StringBuilder sb = new StringBuilder(content);
         // Append the generated content to the end of the page

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/BeforeTokenEditor.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/BeforeTokenEditor.java
@@ -15,7 +15,7 @@ package com.myyearbook.hudson.plugins.confluence.wiki.editors;
 
 import hudson.Extension;
 import hudson.Util;
-import hudson.model.BuildListener;
+import hudson.model.TaskListener;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -38,7 +38,7 @@ public class BeforeTokenEditor extends MarkupEditor {
     }
 
     @Override
-    public String performEdits(final BuildListener listener, final String content,
+    public String performEdits(final TaskListener listener, final String content,
             final String generated, final boolean isNewFormat) throws TokenNotFoundException {
         final StringBuffer sb = new StringBuffer(content);
 

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/BeforeTokenEditor.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/BeforeTokenEditor.java
@@ -17,6 +17,7 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.myyearbook.hudson.plugins.confluence.wiki.generators.MarkupGenerator;
@@ -61,6 +62,7 @@ public class BeforeTokenEditor extends MarkupEditor {
     }
 
     @Extension
+    @Symbol("confluenceBeforeToken")
     public static final class DescriptorImpl extends MarkupEditorDescriptor {
         @Override
         public String getDisplayName() {

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/BetweenTokensEditor.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/BetweenTokensEditor.java
@@ -17,6 +17,7 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.TaskListener;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.myyearbook.hudson.plugins.confluence.wiki.generators.MarkupGenerator;
@@ -83,6 +84,7 @@ public class BetweenTokensEditor extends MarkupEditor {
     }
 
     @Extension
+    @Symbol("confluenceBetweenTokens")
     public static final class DescriptorImpl extends MarkupEditorDescriptor {
         @Override
         public String getDisplayName() {

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/BetweenTokensEditor.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/BetweenTokensEditor.java
@@ -15,7 +15,7 @@ package com.myyearbook.hudson.plugins.confluence.wiki.editors;
 
 import hudson.Extension;
 import hudson.Util;
-import hudson.model.BuildListener;
+import hudson.model.TaskListener;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -49,7 +49,7 @@ public class BetweenTokensEditor extends MarkupEditor {
      * @throws TokenNotFoundException
      */
     @Override
-    public String performEdits(final BuildListener listener, final String content,
+    public String performEdits(final TaskListener listener, final String content,
             final String generated, final boolean isNewFormat) throws TokenNotFoundException {
         final StringBuffer sb = new StringBuffer(content);
 

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/EntirePageEditor.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/EntirePageEditor.java
@@ -16,6 +16,7 @@ package com.myyearbook.hudson.plugins.confluence.wiki.editors;
 import hudson.Extension;
 import hudson.model.TaskListener;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.myyearbook.hudson.plugins.confluence.wiki.generators.MarkupGenerator;
@@ -39,6 +40,7 @@ public class EntirePageEditor extends MarkupEditor {
     }
 
     @Extension
+    @Symbol("confluenceWritePage")
     public static final class DescriptorImpl extends MarkupEditorDescriptor {
         @Override
         public String getDisplayName() {

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/EntirePageEditor.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/EntirePageEditor.java
@@ -14,7 +14,7 @@
 package com.myyearbook.hudson.plugins.confluence.wiki.editors;
 
 import hudson.Extension;
-import hudson.model.BuildListener;
+import hudson.model.TaskListener;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -33,7 +33,7 @@ public class EntirePageEditor extends MarkupEditor {
     }
 
     @Override
-    public String performEdits(final BuildListener listener, final String content,
+    public String performEdits(final TaskListener listener, final String content,
             final String generated, final boolean isNewFormat) {
         return generated;
     }

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/MarkupEditor.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/MarkupEditor.java
@@ -15,10 +15,11 @@ package com.myyearbook.hudson.plugins.confluence.wiki.editors;
 
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
-import hudson.model.BuildListener;
+import hudson.FilePath;
 import hudson.model.Describable;
-import hudson.model.AbstractBuild;
 import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 
 
 import com.myyearbook.hudson.plugins.confluence.wiki.generators.MarkupGenerator;
@@ -61,10 +62,10 @@ public abstract class MarkupEditor implements Describable<MarkupEditor>, Extensi
      * @return
      * @throws TokenNotFoundException
      */
-    public final String performReplacement(final AbstractBuild<?, ?> build,
-            final BuildListener listener, final String content, boolean isNewFormat, List<RemoteAttachment> remoteAttachments)
+    public final String performReplacement(final Run<?, ?> build, FilePath filePath,
+            final TaskListener listener, final String content, boolean isNewFormat, List<RemoteAttachment> remoteAttachments)
             throws TokenNotFoundException {
-        final String generated = generator.generateMarkup(build, listener, remoteAttachments);
+        final String generated = generator.generateMarkup(build, filePath, listener, remoteAttachments);
 
         // Perform the edit
         return this.performEdits(listener, content, generated, isNewFormat);
@@ -76,7 +77,7 @@ public abstract class MarkupEditor implements Describable<MarkupEditor>, Extensi
      * @param listener
      * @param message
      */
-    protected void log(BuildListener listener, String message) {
+    protected void log(TaskListener listener, String message) {
         listener.getLogger().println("[confluence] " + message);
     }
 
@@ -109,7 +110,7 @@ public abstract class MarkupEditor implements Describable<MarkupEditor>, Extensi
      * @return
      * @throws TokenNotFoundException
      */
-    protected abstract String performEdits(final BuildListener listener, final String content,
+    protected abstract String performEdits(final TaskListener listener, final String content,
             final String generated, final boolean isNewFormat) throws TokenNotFoundException;
 
     /**

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/PrependEditor.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/PrependEditor.java
@@ -16,6 +16,7 @@ package com.myyearbook.hudson.plugins.confluence.wiki.editors;
 import hudson.Extension;
 import hudson.model.TaskListener;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.myyearbook.hudson.plugins.confluence.wiki.generators.MarkupGenerator;
@@ -50,6 +51,7 @@ public class PrependEditor extends MarkupEditor {
     }
 
     @Extension
+    @Symbol("confluencePrependPage")
     public static final class DescriptorImpl extends MarkupEditorDescriptor {
         @Override
         public String getDisplayName() {

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/PrependEditor.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/PrependEditor.java
@@ -14,7 +14,7 @@
 package com.myyearbook.hudson.plugins.confluence.wiki.editors;
 
 import hudson.Extension;
-import hudson.model.BuildListener;
+import hudson.model.TaskListener;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -34,7 +34,7 @@ public class PrependEditor extends MarkupEditor {
     }
 
     @Override
-    public String performEdits(final BuildListener listener, final String content,
+    public String performEdits(final TaskListener listener, final String content,
             final String generated, final boolean isNewFormat) {
         final StringBuilder sb = new StringBuilder(content);
 

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/generators/FileGenerator.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/generators/FileGenerator.java
@@ -16,9 +16,9 @@ package com.myyearbook.hudson.plugins.confluence.wiki.generators;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
-import hudson.model.BuildListener;
-import hudson.model.AbstractBuild;
 import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 
 import java.io.IOException;
 import java.util.List;
@@ -49,15 +49,15 @@ public class FileGenerator extends MarkupGenerator {
     }
 
     @Override
-	public String generateMarkup(AbstractBuild<?, ?> build,
-			BuildListener listener, List<RemoteAttachment> remoteAttachments) {
+	public String generateMarkup(Run<?, ?> build, FilePath filePath,
+			TaskListener listener, List<RemoteAttachment> remoteAttachments) {
         if (this.filename == null) {
             listener.getLogger().println(
                     "[confluence] No file is configured, generating empty markup.");
             return "";
         }
 
-        FilePath markupFile = build.getWorkspace().child(this.filename);
+        FilePath markupFile = filePath.child(this.filename);
 
         try {
             if (!markupFile.exists()) {

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/generators/FileGenerator.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/generators/FileGenerator.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import jenkins.plugins.confluence.soap.v1.RemoteAttachment;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.export.Exported;
 
@@ -79,6 +80,7 @@ public class FileGenerator extends MarkupGenerator {
     }
 
     @Extension
+    @Symbol("confluenceFile")
     public static class DescriptorImpl extends Descriptor<MarkupGenerator> {
         @Override
         public String getDisplayName() {

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/generators/MarkupGenerator.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/generators/MarkupGenerator.java
@@ -15,11 +15,11 @@ package com.myyearbook.hudson.plugins.confluence.wiki.generators;
 
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
-import hudson.model.BuildListener;
+import hudson.FilePath;
 import hudson.model.Describable;
-import hudson.model.AbstractBuild;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 
 import java.io.IOException;
 import java.net.URI;
@@ -63,7 +63,7 @@ public abstract class MarkupGenerator implements Describable<MarkupGenerator>, E
      * @param listener
      * @return
      */
-    public abstract String generateMarkup(AbstractBuild<?, ?> build, BuildListener listener, List<RemoteAttachment> remoteAttachments);
+    public abstract String generateMarkup(Run<?, ?> build, FilePath filePath, TaskListener listener, List<RemoteAttachment> remoteAttachments);
 
     /**
      * Expands replacement variables in the generated text
@@ -73,7 +73,7 @@ public abstract class MarkupGenerator implements Describable<MarkupGenerator>, E
      * @param generated
      * @return
      */
-    protected String expand(final AbstractBuild<?, ?> build, final BuildListener listener,
+    protected String expand(final Run<?, ?> build, final TaskListener listener,
             final String generated, List<RemoteAttachment> remoteAttachments) {
 	//If expansion failed, just return the unexpanded text
 	String result = generated;
@@ -96,7 +96,7 @@ public abstract class MarkupGenerator implements Describable<MarkupGenerator>, E
      * @param remoteAttachments
      * @return
      */
-    protected String expandAttachmentsLink(final BuildListener listener, String generated, List<RemoteAttachment> remoteAttachments ){
+    protected String expandAttachmentsLink(final TaskListener listener, String generated, List<RemoteAttachment> remoteAttachments ){
 	String result = generated;
 	for (int i = 0; i < remoteAttachments.size(); i++) {
 		RemoteAttachment attachment = remoteAttachments.get(i);

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/generators/PlainTextGenerator.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/generators/PlainTextGenerator.java
@@ -14,9 +14,10 @@
 package com.myyearbook.hudson.plugins.confluence.wiki.generators;
 
 import hudson.Extension;
-import hudson.model.BuildListener;
-import hudson.model.AbstractBuild;
+import hudson.FilePath;
 import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 
 import java.util.List;
 
@@ -44,9 +45,9 @@ public class PlainTextGenerator extends MarkupGenerator {
     }
 
     @Override
-	public String generateMarkup(AbstractBuild<?, ?> build,
-			BuildListener listener, List<RemoteAttachment> remoteAttachments) {
-	return expand(build, listener, this.text, remoteAttachments);
+	public String generateMarkup(Run<?, ?> build, FilePath filePath,
+			TaskListener listener, List<RemoteAttachment> remoteAttachments) {
+	    return expand(build, listener, this.text, remoteAttachments);
     }
 
     @Extension

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/generators/PlainTextGenerator.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/wiki/generators/PlainTextGenerator.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import jenkins.plugins.confluence.soap.v1.RemoteAttachment;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -51,6 +52,7 @@ public class PlainTextGenerator extends MarkupGenerator {
     }
 
     @Extension
+    @Symbol("confluenceText")
     public static class DescriptorImpl extends Descriptor<MarkupGenerator> {
         @Override
         public String getDisplayName() {

--- a/src/main/resources/com/myyearbook/hudson/plugins/confluence/ConfluencePublisher/config.jelly
+++ b/src/main/resources/com/myyearbook/hudson/plugins/confluence/ConfluencePublisher/config.jelly
@@ -13,7 +13,7 @@
 
     <f:entry title="" field="buildIfUnstable">
         <f:checkbox title="Publish even if the build is unstable"
-            checked="${instance.shouldBuildIfUnstable()}" default="false" />
+            checked="${instance.isBuildIfUnstable()}" default="false" />
     </f:entry>
 
     <f:entry title="Space" field="spaceName">
@@ -37,12 +37,12 @@
 
     <f:entry title="Artifacts" field="attachArchivedArtifacts">
         <f:checkbox title="Attach archived artifacts to page"
-            checked="${instance.shouldAttachArchivedArtifacts()}" default="true" />
+            checked="${instance.isAttachArchivedArtifacts()}" default="true" />
     </f:entry>
 
 	<f:entry title="" field="replaceAttachments">
         <f:checkbox title="Replace file if it's already exist"
-            checked="${instance.shouldReplaceAttachments()}" default="false" />
+            checked="${instance.isReplaceAttachments()}" default="false" />
     </f:entry>
 
     <f:entry title="Other files to attach" field="fileSet">

--- a/src/main/resources/com/myyearbook/hudson/plugins/confluence/publishConfluence.groovy
+++ b/src/main/resources/com/myyearbook/hudson/plugins/confluence/publishConfluence.groovy
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Francois Ferrand
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.myyearbook.hudson.plugins.confluence
+
+import org.apache.commons.lang.WordUtils
+import org.jenkinsci.Symbol
+import com.cloudbees.groovy.cps.NonCPS
+import com.myyearbook.hudson.plugins.confluence.wiki.editors.MarkupEditor
+import com.myyearbook.hudson.plugins.confluence.wiki.generators.MarkupGenerator
+
+/** Publish to confluence.
+ * <code>
+ * publishConfluence(siteName:'foo.bar.org', spaceName:'FOO', pageName:'bar') {
+ *     append      text:"This goes before"
+ *     beforeToken file:"stuff.txt", markerToken:"HERE"
+ * }
+ * </code>
+ */
+def call(Map args, Closure body) {
+    body.resolveStrategy = Closure.DELEGATE_FIRST
+    body.delegate = new Dsl(args)
+    body.call()
+
+    step createPublisher(args)
+}
+
+/** Publish to confluence.
+ * This overload is added to keep compatibility with snippetgenerator:
+ *
+ * <code>
+ * publishConfluence siteName:'foo.bar.org', spaceName:'FOO', pageName:'bar', editorList: [
+ *     confluenceAppendPage(confluenceText plainText:"This goes before"),
+ *     beforeToken(confluenceFile(file:"stuff.txt"), markerToken:"HERE")
+ * ]
+ * </code>
+ *
+ */
+def call(Map args) {
+    step createPublisher(args)
+}
+
+@NonCPS
+private def createPublisher(args) {
+    [$class:'com.myyearbook.hudson.plugins.confluence.ConfluencePublisher', *:args]
+}
+
+class Dsl implements Serializable {
+    private args;
+
+    Dsl(args) {
+        this.args = args
+        this.args['editorList'] = []
+    }
+
+    @NonCPS
+    private getSymbolName(descriptor) {
+        def symbol = descriptor.class.getAnnotation(Symbol.class)?.value()
+        if (!symbol)
+            return null
+
+        def symbolMatcher = symbol =~ /^\[confluence(.*)\]$/
+        return WordUtils.uncapitalize(symbolMatcher[0][1])
+    }
+
+    @NonCPS
+    def methodMissing(String name, Object args) {
+        // Try an editor matching the name of the method
+        def editorClassName = MarkupEditor.all().find { descriptor ->
+            def editorName = getSymbolName(descriptor)
+            if (name == editorName)
+                return true
+        }?.clazz?.name
+        if (!editorClassName) {
+            // Method does not match an editor, so simply set the property of the same name
+            if (args.length != 1)
+                throw new MissingMethodException(name, delegate, args)
+            this.args[name] = args[0]
+            return
+        }
+
+        // Editing commands must be called with named arguments
+        if (!args[0] instanceof Map)
+            throw new MissingMethodException(name, delegate, args)
+
+        // Replace generator argument
+        Map namedArgs = args[0] as Map
+        MarkupGenerator.all().any { descriptor ->
+            def propertyName = getSymbolName(descriptor)
+            if (!propertyName || !namedArgs.containsKey(propertyName))
+                return
+
+            def value = namedArgs[propertyName]
+            namedArgs.remove(propertyName)
+            namedArgs['generator'] = [$class:descriptor.clazz.name, "$propertyName":value]
+            return true
+        }
+
+        this.args['editorList'] << [$class:editorClassName, *:namedArgs]
+    }
+
+    @NonCPS
+    def propertyMissing(String name) {
+        args.getAt(name)
+    }
+}

--- a/src/test/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/BetweenTokensEditorTest.java
+++ b/src/test/java/com/myyearbook/hudson/plugins/confluence/wiki/editors/BetweenTokensEditorTest.java
@@ -1,6 +1,6 @@
 package com.myyearbook.hudson.plugins.confluence.wiki.editors;
 
-import hudson.model.BuildListener;
+import hudson.model.TaskListener;
 import junit.framework.TestCase;
 
 import org.junit.After;
@@ -20,7 +20,7 @@ public class BetweenTokensEditorTest extends TestCase {
     private static final String END_TOKEN = "%end%";
 
     @Mock
-    BuildListener buildListener;
+    TaskListener buildListener;
     @Mock
     MarkupGenerator markupGenerator;
 


### PR DESCRIPTION
Support usage of confluence publisher from pipeline.

This can be done in multiple ways:
* Using the `step` command and creating classes explicitely (with [$class: ... ] syntax)
    ```
    step([$class='ConfluencePublisher', siteName: 'confluence', pageName: 'test', spaceName: 'TEST',
              attachArchivedArtifacts: true, editorList: [
                          [$class:"BeforeTokenEditor", generator:[$class:"TextGenerator", text:'goo'], markerToken: 'foo'],
                          [$class:"AppendEditor", generator:[$class:"FileGenerator", file:'content.txt']]
              ]])
    ```
* Using the `publishConfluence` step, creating arguments using the various `confluenceXXXX` methods. This is the code that is generated by the snippet generator.
    ```
    publishConfluence siteName: 'confluence', pageName: 'test', spaceName: 'TEST',
                      attachArchivedArtifacts: true,
                      editorList: [
                          confluenceBeforeToken(generator: confluenceText('goo'), markerToken: 'foo'),
                          confluenceAppendPage(confluenceFile('content.txt'))
                      ]
    ```
* Using `publishConfluence` global variable step, which accepts a closure with a (simpler) DSL
    ```
    publishConfluence(siteName: 'confluence', pageName: 'test', spaceName: 'TEST') {
                      attachArchivedArtifacts true
                      beforeToken text:'goo', markerToken: 'foo'
                      appendPage file:'content.txt'
   }
   ```
