### PR TITLE
Fix reloading configuration in projects

### DIFF
--- a/src/main/resources/com/myyearbook/hudson/plugins/confluence/ConfluencePublisher/config.jelly
+++ b/src/main/resources/com/myyearbook/hudson/plugins/confluence/ConfluencePublisher/config.jelly
@@ -51,7 +51,7 @@
 
     <f:entry title="Wiki Markup Replacements" help="${descriptor.getHelpFile('editorList')}">
         <f:hetero-list name="editorList" hasHeader="true"
-            descriptors="${descriptor.getEditors()}" items="${instance.configuredEditors}"
+            descriptors="${descriptor.getEditors()}" items="${instance.editorList}"
             addCaption="Add Replacement" />
     </f:entry>
 


### PR DESCRIPTION
When editing the configuration of freestyle/matrix projects, the wiki
markup replacements were not reloaded: this would cause all these to be
lost whenever the project configuration is edited (likely for changing
other fields).