### PR TITLE
Fixes attachment file stream not closed properly

### DIFF
--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/ConfluenceSession.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/ConfluenceSession.java
@@ -36,6 +36,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.rmi.RemoteException;
 import java.util.Arrays;
 import java.util.List;
@@ -184,12 +185,14 @@ public class ConfluenceSession {
         try {
             File uploadFile = File.createTempFile("conf-upload-", null);
             try (BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(uploadFile.getAbsoluteFile().getPath()))) {
-                bos.write(IOUtils.toByteArray(file.open()));
-                bos.flush();
-                AttachmentUpload attachment = new AttachmentUpload(uploadFile, file.getName(), contentType, comment, false);
-                return attachmentService
-                        .addAttachments(ContentId.of(pageId), Arrays.asList(attachment))
-                        .claim();
+                try (InputStream inSt = file.open()) {
+                    bos.write(IOUtils.toByteArray(inSt));
+                    bos.flush();
+                    AttachmentUpload attachment = new AttachmentUpload(uploadFile, file.getName(), contentType, comment, false);
+                    return attachmentService
+                            .addAttachments(ContentId.of(pageId), Arrays.asList(attachment))
+                            .claim();
+                }
             } catch (IOException ie) {
                 log.severe(ie.getMessage());
             } finally {


### PR DESCRIPTION
We had a strange behavior using the confluence publisher plugin where after a job published a file to confluence, the next build always failed to clean the workspace.

```
Running as SYSTEM
[EnvInject] - Loading node environment variables.
Building in workspace D:\jenkins-workspace\xxx
[WS-CLEANUP] Deleting project workspace...
[WS-CLEANUP] Deferred wipeout is used...
ERROR: [WS-CLEANUP] Cannot delete workspace: Unable to delete 'D:\jenkins-workspace\xxx'. Tried 3 times (of a maximum of 3) waiting 0.1 seconds between attempts.
ERROR: Cannot delete workspace: Unable to delete 'D:\jenkins-workspace\xxx'. Tried 3 times (of a maximum of 3) waiting 0.1 seconds between attempts.
Finished: FAILURE
```

After a reboot of jenkins it worked again as expected.

Turned out the the stream reading the attachment file is not getting closed properly, which is what is fixed here.