### PR TITLE
[JENKINS-67163] JEP-233 breaks Confluence Publisher

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2012 MeetMe, Inc.
     Copyright 2011-2012 Insider Guides, Inc.
@@ -17,40 +18,31 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.48</version>
+        <version>4.31</version>
         <relativePath />
     </parent>
 
     <properties>
-        <jenkins.version>2.185</jenkins.version>
+        <revision>2.0.7</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <jenkins.version>2.321</jenkins.version>
         <java.level>8</java.level>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <no-test-jar>false</no-test-jar>
         <!-- Use the same configuration than before. -->
-        <findbugs.failOnError>false</findbugs.failOnError>
+        <spotbugs.failOnError>false</spotbugs.failOnError>
     </properties>
 
 
     <artifactId>confluence-publisher</artifactId>
     <name>Confluence Publisher</name>
     <description>Publish build artifacts to an Atlassian Confluence wiki</description>
-    <version>2.0.7-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
-    <url>https://github.com/jenkinsci/confluence-publisher-plugin/</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <organization>
         <name>MeetMe, Inc.</name>
@@ -88,21 +80,45 @@
         </developer>
     </developers>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.319.x</artifactId>
+                <version>1013.vf8058992a042</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.73</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.20</version>
         </dependency>
         <dependency>
             <groupId>com.atlassian.confluence</groupId>
             <artifactId>confluence-rest-client</artifactId>
-            <version>6.15.7</version>
+            <version>7.14.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -111,22 +127,16 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.8.0</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
         </dependency>
     </dependencies>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/confluence-publisher-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/confluence-publisher-plugin.git</developerConnection>
-        <url>http://github.com/jenkinsci/confluence-publisher-plugin</url>
-        <tag>HEAD</tag>
+        <connection>scm:git:https://github.com/${gitHubRepo}</connection>
+        <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
     </scm>
 
     <repositories>

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/ConfluenceSession.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/ConfluenceSession.java
@@ -29,6 +29,7 @@ import com.atlassian.util.concurrent.Promise;
 import com.google.common.collect.Collections2;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.util.VirtualFile;
 import org.apache.commons.io.IOUtils;
 
@@ -119,7 +120,7 @@ public class ConfluenceSession {
      * Get a Space by key name
      *
      * @param spaceKey
-     * @return {@link Promise<Option<Space>>} instance
+     * @return {@link Promise} instance
      */
     public Option<Space> getSpace(String spaceKey) throws ServiceException {
         return spaceService.find()
@@ -129,7 +130,7 @@ public class ConfluenceSession {
     /**
      * Get a PageContent by Page key
      * @param contentId
-     * @return {@link Optional<Content>} instance
+     * @return {@link Optional} instance
      */
     public Optional<Content> getContent(String contentId) throws ServiceException {
         return contentService.find(expansions)
@@ -141,7 +142,7 @@ public class ConfluenceSession {
      * Get a Content by spaceKey and Page title
      * @param spaceKey
      * @param pageTitle
-     * @return {@link Optional<Content>} instance
+     * @return {@link Optional} instance
      */
     public Optional<Content> getContent(String spaceKey, String pageTitle, boolean expanded) throws ServiceException {
         return contentService.find(expanded ? expansions : null)
@@ -164,6 +165,7 @@ public class ConfluenceSession {
      * @return List of {@link Content}
      * @throws ServiceException
      */
+    @SuppressFBWarnings(value = "NP_NONNULL_PARAM_VIOLATION", justification = "false positive")
     public List<Content> getAttachments(long pageId) throws ServiceException {
         return attachmentService.find(toExpansionsArray("body.storage"))
                 .withContainerId(ContentId.of(pageId))
@@ -177,8 +179,7 @@ public class ConfluenceSession {
      * @param file
      * @param contentType
      * @param comment
-     * @return {@link PageResponse<Content>} instance that was created on the server
-     * @throws RemoteException
+     * @return {@link PageResponse} instance that was created on the server
      */
     public PageResponse<Content> addAttachment(long pageId, VirtualFile file, String contentType,
                                                String comment) throws ServiceException {
@@ -258,6 +259,7 @@ public class ConfluenceSession {
 
     }
 
+    @SuppressFBWarnings(value = "NP_NONNULL_PARAM_VIOLATION", justification = "false positive")
     public PageResponse<Label> getLabels(long id) {
         return (PageResponse<Label>) remoteContentLabelService
                 .getLabels(ContentId.of(id), Arrays.asList(labelPrefix), null).claim();


### PR DESCRIPTION
See [JENKINS-67163](https://issues.jenkins.io/browse/JENKINS-67163). Adapts the Confluence Publisher plugin to the Guava and Guice upgrades in Jenkins core by updating `confluence-rest-client` to 7.13.0, which depends on Guava 26.0-jre (which is compatible with the version now shipped by Jenkins core).