### PR TITLE
ignore confluence-rest-client in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       - "jetersen"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: com.atlassian.confluence:confluence-rest-client
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
as versioning on the maven package is a mess and dependabot cannot handle it accordingly