### PR TITLE
[JENKINS-68458] Prepare Confluence Publisher for removal of JAXB and Java 11 requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
             </exclusions>
         </dependency>
         <dependency>
+              <groupId>io.jenkins.plugins</groupId>
+              <artifactId>jaxb</artifactId>
+              <version>2.3.6-1</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
See [JENKINS-68458](https://issues.jenkins.io/browse/JENKINS-68458). This plugin bundles a fork of Jackson 1 (1.9.13-atlassian-6), which consumes JAXB. But when running on Java 9+, JAXB is not included on the classpath by default. The only way for a plugin to have access to JAXB when running on Jenkins 2.164 or later is to declare a plugin-to-plugin dependency on JAXB (recommended) or to embed JAXB into its `.jpi` file. This PR does the former to ensure that Confluence Publisher always has access to JAXB on its classpath. CC @jetersen 