### PR TITLE
Add support for bearer token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ configuration. If authentication credentials are not supplied, the
 plugin will act as an anonymous user – as such your Confluence
 configuration must support anonymous attachments for that to work.
 
+The plugin supports both basic authentication (by providing username
+and password) and bearer authentication (by providing an access token
+as the password leaving the username empty).
+
 ![](docs/images/Screen_shot_2011-02-28_at_8.17.13_PM.png){width="800"}
 
 ### Job Configuration

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/api/BasicOrBearerTokenAuthWebResourceProvider.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/api/BasicOrBearerTokenAuthWebResourceProvider.java
@@ -1,0 +1,53 @@
+package com.myyearbook.hudson.plugins.confluence.api;
+
+import com.atlassian.confluence.rest.client.authentication.AuthenticatedWebResourceProvider;
+import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.WebResource;
+import org.apache.commons.lang3.ArrayUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+public class BasicOrBearerTokenAuthWebResourceProvider extends AuthenticatedWebResourceProvider {
+    private static final Logger log = LoggerFactory.getLogger(BasicOrBearerTokenAuthWebResourceProvider.class);
+
+    private char[] accessToken;
+
+    public BasicOrBearerTokenAuthWebResourceProvider(Client client, String baseUrl, String path) {
+        super(client, baseUrl, path);
+    }
+
+    @Override
+    public WebResource newRestWebResource() {
+        // create resource with a basic authentication filter if username and password are provided
+        WebResource resource = super.newRestWebResource();
+        if (this.accessToken != null) {
+            resource.addFilter(new BearerTokenFilter(new String(this.accessToken)));
+            log.debug("Using web resource with token authentication");
+        } else {
+            log.debug("Leaving original web resource unchanged");
+        }
+
+        return resource;
+    }
+
+    @Override
+    public void setAuthContext(String username, char[] password) {
+        super.setAuthContext(username, password);
+
+        if (this.accessToken != null) {
+            // override old access token
+            Arrays.fill(this.accessToken, '\u0000');
+        }
+
+        if (username != null && username.length() > 0) {
+            // username not null means, basic authentication is requested
+            accessToken = null;
+            return;
+        }
+
+        this.accessToken = ArrayUtils.clone(password);
+    }
+}
+

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/api/BearerTokenFilter.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/api/BearerTokenFilter.java
@@ -1,0 +1,26 @@
+package com.myyearbook.hudson.plugins.confluence.api;
+
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientRequest;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.filter.ClientFilter;
+
+import javax.ws.rs.core.HttpHeaders;
+
+public final class BearerTokenFilter extends ClientFilter {
+
+    private final String token;
+
+    public BearerTokenFilter(String token) {
+
+        this.token = token;
+    }
+
+    @Override
+    public ClientResponse handle(ClientRequest cr) throws ClientHandlerException {
+        if (!cr.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
+            cr.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        }
+        return getNext().handle(cr);
+    }
+}

--- a/src/main/resources/com/myyearbook/hudson/plugins/confluence/ConfluencePublisher/global.jelly
+++ b/src/main/resources/com/myyearbook/hudson/plugins/confluence/ConfluencePublisher/global.jelly
@@ -16,7 +16,7 @@
 						<f:textbox />
 					</f:entry>
 
-					<f:entry title="Password" field="password">
+					<f:entry title="Password / Access Token" field="password">
 						<f:password />
 					</f:entry>
 


### PR DESCRIPTION
Our IT team disabled basic authentication to the conflunce REST api entirely, so we needed to find a new way to access our confluence.

Fortunately the confluence REST API does allow bearer authentication with an access token as well. Unfortunately however the confluence-rest-client library does not support bearer authentication (not even with the newest version), so I had to come up with my own implementiation of the AuthenticatedWebResourceProvider making bearer authentication possible.

I tried my best to make my changes backwards compatible, that is:
- testing against an old confluence with basic authentication enabled
- testing against our instance with bearer authentication only

As I have no instance without a login needed I can not guarantee that anonymous acccess still works, but I think it does.

I also updated the README to clarify how to configure basic vs bearer authentication.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Please review @jetersen 

Hoping to get this merged sooner then my last PR.