### PR TITLE
chore(Jenkinsfile): use container agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
 #!/usr/bin/env groovy
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(platforms: ['linux'])
+buildPlugin(useContainerAgent: true, platforms: ['linux'])


### PR DESCRIPTION
From https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile, I've set the use of a container agent in the Jenkinsfile so the builds will be done in a cluster container agent instead of a VM: quicker and less costly.

Tested with success in https://ci.jenkins.io/job/Plugins/job/confluence-publisher-plugin/job/PR-103/6/console while debugging https://github.com/jenkins-infra/helpdesk/issues/3434

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [N/A] Link to relevant issues in GitHub or Jira
- [N/A] Link to relevant pull requests, esp. upstream and downstream changes
- [N/A] Ensure you have provided tests - that demonstrates feature works or fixes the issue

