### PR TITLE
Remove leftover jelly file

### DIFF
--- a/src/main/resources/com/myyearbook/hudson/plugins/confluence/credentials/ConfluenceApiTokenImpl/credentials.jelly
+++ b/src/main/resources/com/myyearbook/hudson/plugins/confluence/credentials/ConfluenceApiTokenImpl/credentials.jelly
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
-    <f:entry title="${%API token}" field="apiToken">
-        <f:password/>
-    </f:entry>
-    <st:include page="id-and-description" class="${descriptor.clazz}"/>
-</j:jelly>


### PR DESCRIPTION
The jelly file for the class ConfluenceApiTokenImpl was not removed while developing #103.
This PR removes the jelly file because it is not needed anymore and can cause potential future irritations as of why it is there.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue