### PR TITLE
Clean up plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,6 @@
 #!/usr/bin/env groovy
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(
-  useContainerAgent: true,
-  configurations: [
-    [ platform: "linux", jdk: "11" ],
-    [ platform: "linux", jdk: "17" ],
-  ],
-)
+buildPlugin(useContainerAgent: true, configurations: [
+  [platform: 'linux', jdk: 17],
+  [platform: 'windows', jdk: 11],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.58</version>
+        <version>4.67</version>
         <relativePath />
     </parent>
 
@@ -30,8 +30,8 @@
         <jenkins.version>2.361.4</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <no-test-jar>false</no-test-jar>
-        <!-- Use the same configuration than before. -->
-        <spotbugs.failOnError>false</spotbugs.failOnError>
+        <!-- TODO fix existing violations -->
+        <spotbugs.threshold>High</spotbugs.threshold>
     </properties>
 
 
@@ -83,7 +83,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.361.x</artifactId>
-                <version>1968.vb_14a_29e76128</version>
+                <version>2102.v854b_fec19c92</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -101,27 +101,45 @@
             <artifactId>workflow-cps</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.atlassian.confluence</groupId>
             <artifactId>confluence-rest-client</artifactId>
             <version>7.14.0</version>
             <exclusions>
+                <!-- Provided by Jenkins core -->
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.j2objc</groupId>
-                    <artifactId>j2objc-annotations</artifactId>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <!-- Provided by commons-lang3-api plugin -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
@@ -134,11 +152,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/ConfluencePublisher.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/ConfluencePublisher.java
@@ -276,8 +276,9 @@ public final class ConfluencePublisher extends Notifier implements Saveable, Sim
                         + " workspace artifact(s) to upload to Confluence...");
 
                 for (FilePath file : workspaceFiles) {
-                    if (!files.contains(file)) {
-                        files.add(file.toVirtualFile());
+                    VirtualFile vf = file.toVirtualFile();
+                    if (!files.contains(vf)) {
+                        files.add(vf);
                     } else {
                         // Don't include the file twice if it's already in the
                         // list

--- a/src/main/java/com/myyearbook/hudson/plugins/confluence/ConfluenceSite.java
+++ b/src/main/java/com/myyearbook/hudson/plugins/confluence/ConfluenceSite.java
@@ -48,7 +48,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.net.MalformedURLException;


### PR DESCRIPTION
Removes the following unneeded JARs from the JPI:

commons-io-2.11.0.jar
commons-lang3-3.9.jar
jsr305-3.0.1.jar
slf4j-api-1.7.36.jar

JSR305 is deprecated and the other three are already bundled in Jenkins core, superseding the version bundled in any plugin JPIs.