### PR TITLE
Remove usages of Prototype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <changelist>9999-SNAPSHOT</changelist>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.410</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <no-test-jar>false</no-test-jar>
         <!-- Use the same configuration than before. -->
@@ -82,8 +82,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>1968.vb_14a_29e76128</version>
+                <artifactId>bom-2.401.x</artifactId>
+                <version>2244.vd60654536b_96</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/resources/com/myyearbook/hudson/plugins/confluence/ConfluencePublisher/config.jelly
+++ b/src/main/resources/com/myyearbook/hudson/plugins/confluence/ConfluencePublisher/config.jelly
@@ -18,17 +18,17 @@
 
     <f:entry title="Space" field="spaceName">
         <f:textbox clazz="required"
-            checkUrl="'descriptorByName/ConfluencePublisher/spaceNameCheck?siteName='+Form.findMatchingInput(this,'siteName').value+'&amp;spaceName='+escape(this.value)" />
+            checkUrl="'descriptorByName/ConfluencePublisher/spaceNameCheck?siteName='+findMatchingFormInput(this,'siteName').value+'&amp;spaceName='+escape(this.value)" />
     </f:entry>
 
     <f:entry title="Page" field="pageName">
         <f:textbox clazz="required"
-            checkUrl="'descriptorByName/ConfluencePublisher/pageNameCheck?siteName='+Form.findMatchingInput(this,'siteName').value+'&amp;spaceName='+Form.findMatchingInput(this,'_.spaceName').value+'&amp;pageName='+escape(this.value)" />
+            checkUrl="'descriptorByName/ConfluencePublisher/pageNameCheck?siteName='+findMatchingFormInput(this,'siteName').value+'&amp;spaceName='+findMatchingFormInput(this,'_.spaceName').value+'&amp;pageName='+escape(this.value)" />
     </f:entry>
 
     <f:entry title="Parent Page ID" field="parentId">
         <f:textbox
-            checkUrl="'descriptorByName/ConfluencePublisher/parentIdCheck?siteName='+Form.findMatchingInput(this,'siteName').value+'&amp;spaceName='+Form.findMatchingInput(this,'_.spaceName').value+'&amp;parentId='+escape(this.value)" />
+            checkUrl="'descriptorByName/ConfluencePublisher/parentIdCheck?siteName='+findMatchingFormInput(this,'siteName').value+'&amp;spaceName='+findMatchingFormInput(this,'_.spaceName').value+'&amp;parentId='+escape(this.value)" />
     </f:entry>
 
     <f:entry title="Page Labels" field="labels" help="${descriptor.getHelpFile('labels')}">


### PR DESCRIPTION
Remove usages of Prototype in favor of the new API introduced in https://github.com/jenkinsci/jenkins/pull/8008 (2.406) and subsequently corrected in https://github.com/jenkinsci/jenkins/pull/8100 (2.410).