### PR TITLE
Bundle javax.mail:mail for JDK support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>javax.mail</groupId>
+          <artifactId>mail</artifactId>
+          <version>1.4.7</version>
+        </dependency>
     </dependencies>
 
     <scm>


### PR DESCRIPTION
Bundles `javax.mail:mail`, which is no longer included with the JVM.

### Testing done
Ran a pipeline that uses the `publishConfluence` step on a Jenkins running on JVM 17 with release `163.vf906edb_73cce` of confluence-publisher-plugin. The pipeline failed with a `ClassNotFoundException` due to not finding `javax.mail.MessagingException`. Made a local build of the same release, but with this patch applied. Re-ran the pipeline. This time, it worked.

Also ran `com.sun.jersey.spi.service.ServiceFinder.find(javax.ws.rs.ext.MessageBodyReader.class, true).toClassArray()` in the Script Console of the same Jenkins instance. With release `163.vf906edb_73cce`, it failed with a `ClassNotFoundException` due to `javax.mail.MessagingException` not existing. With this change, no exception was thrown.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```